### PR TITLE
Fixed declaration incompatibility

### DIFF
--- a/src/Requests/LegalNotices/AbstractRequest.php
+++ b/src/Requests/LegalNotices/AbstractRequest.php
@@ -4,7 +4,7 @@ namespace SoluzioneSoftware\Iubenda\Requests\LegalNotices;
 
 abstract class AbstractRequest extends \SoluzioneSoftware\Iubenda\Requests\AbstractRequest
 {
-    protected function getUrl(string $path = '/')
+    protected function getUrl(string $path = '/'): string
     {
         return parent::getUrl('/legal_notices' . $path);
     }


### PR DESCRIPTION
The declaration of the getUrl function is not compatible with the parent class because the returned data type is missing.